### PR TITLE
Removes the unecessary permission for external storage access on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -111,10 +111,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-        </config-file>
-
         <source-file src="src/android/EncodingException.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/FileExistsException.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/InvalidModificationException.java" target-dir="src/org/apache/cordova/file" />
@@ -166,7 +162,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/Filesystem.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/LocalFilesystem.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/ContentFilesystem.java" target-dir="src/org/apache/cordova/file" />
-        
+
         <!-- android specific file apis -->
         <js-module src="www/android/FileSystem.js" name="androidFileSystem">
             <merges target="window.FileSystem" />


### PR DESCRIPTION
I suggest we'll do it this way, introducing the new ``easybib`` branch which is based on the latest released version (1.3.3) of the plugin. Then we can use the branch in our mobile app.